### PR TITLE
만국박람회 [STEP3] brendan, vapor 

### DIFF
--- a/Expo1900/Expo1900/ViewController/ExpoDetailViewController.swift
+++ b/Expo1900/Expo1900/ViewController/ExpoDetailViewController.swift
@@ -64,14 +64,15 @@ class ExpoDetailViewController: UIViewController {
         NSLayoutConstraint.activate([
             outerStackView.topAnchor.constraint(equalTo: safeArea.topAnchor),
             outerStackView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            outerStackView.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor),
+            outerStackView.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor, constant: 12),
             outerStackView.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor),
             scrollView.topAnchor.constraint(equalTo: outerStackView.topAnchor),
             scrollView.bottomAnchor.constraint(equalTo: outerStackView.bottomAnchor),
-            contentStackView.widthAnchor.constraint(equalTo: scrollView.widthAnchor, constant: -24),
-            contentStackView.centerXAnchor.constraint(equalTo: scrollView.centerXAnchor),
+            contentStackView.widthAnchor.constraint(equalTo: scrollView.widthAnchor, constant: -12),
             contentStackView.topAnchor.constraint(equalTo: scrollView.topAnchor, constant: 10),
             contentStackView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor, constant: -20),
+            contentStackView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
+            contentStackView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor, constant: -12),
             descLabel.widthAnchor.constraint(equalTo: contentStackView.widthAnchor)
         ])
     }

--- a/Expo1900/Expo1900/ViewController/PosterViewController.swift
+++ b/Expo1900/Expo1900/ViewController/PosterViewController.swift
@@ -79,6 +79,7 @@ class PosterViewController: UIViewController {
         title = "메인"
         view.backgroundColor = UIColor.white
         setupScrollView()
+        setupExpoButton()
         bindExpositionModel()
     }
     
@@ -117,6 +118,11 @@ class PosterViewController: UIViewController {
             rightFlagImageView.heightAnchor.constraint(equalToConstant: 40),
             rightFlagImageView.widthAnchor.constraint(equalToConstant: 40)
         ])
+    }
+    
+    private func setupExpoButton() {
+        showExpoButton.titleLabel?.topAnchor.constraint(equalTo: showExpoButton.topAnchor, constant: 15).isActive = true
+        showExpoButton.titleLabel?.bottomAnchor.constraint(equalTo: showExpoButton.bottomAnchor, constant: -15).isActive = true
     }
     
     private func bindExpositionModel() {

--- a/Expo1900/Expo1900/ViewController/PosterViewController.swift
+++ b/Expo1900/Expo1900/ViewController/PosterViewController.swift
@@ -91,11 +91,13 @@ class PosterViewController: UIViewController {
     private func setupScrollView() {
         view.addSubview(scrollView)
         
+        let safeArea: UILayoutGuide = view.safeAreaLayoutGuide
+        
         NSLayoutConstraint.activate([
-            scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            scrollView.topAnchor.constraint(equalTo: safeArea.topAnchor),
             scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor),
             contentStackView.centerXAnchor.constraint(equalTo: scrollView.centerXAnchor),
             contentStackView.topAnchor.constraint(equalTo: scrollView.topAnchor),
             contentStackView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor, constant: -25),


### PR DESCRIPTION
@odong-Tree 

오동나무 안녕하세요 ~ STEP3 + BONUS 를 진행한 brendan, vapor 입니다.
이번에도 리뷰 부탁드리겠습니다. 감사합니다 ~! 


# 작업사항 
* 저희는 STEP3 를 BONUS도 같이 진행했습니다. 
* 세번째 화면에서 가로모드인 경우에는 이미지를 다르게 보여주도록 구현했습니다. 
    * 저희는 최대한 코드를 건드리지 않는 방향으로 구현하려고 했습니다.
    * 기존에는 이미지와 `label`이 담긴 `contentStackView`가 있고, 이 스택뷰를 `scrollView`안에서 가지는 구조였습니다. 
    * 이 `scrollView`를 한번더 감싸는 `outerStackView`를 가지도록 변경했습니다.  
    * 가로모드와 세로모드인 경우를 옵저빙하여, 이미지를 `removeFromSuperView`를 사용하여 다른 `outerStackView`안에 넣어주도록 구현했습니다. 


# 고민한 점 
* 첫번째 화면의 하단 버튼에 `dynamic type`을 적용할 경우, 가장 큰 폰트사이즈일 때 버튼의 글자가 위쪽 본문의 글자와 겹치는 현상 
* ![Pasted Graphic 23](https://user-images.githubusercontent.com/48749182/149733919-0db18277-22c7-41e6-a594-81045e341381.png)
* iOS 15만 대응할 경우, button의 style을 plain으로 변경하면 해결되는 문제였지만, iOS 14도 대응하기 위해 좀 더 고민했습니다.
* 그래서 브랜든이 `button`안의 `titleLabel`의 `top`, `bottom anchor`를 `button`의 `top`, `bottom`과 `constraint`를 주니 해결됐습니다
* ![image](https://user-images.githubusercontent.com/48749182/149734329-cb9a862a-3e0c-4c95-b902-177b6a64de4d.png)


