### PR TITLE
만국박람회 [STEP3] liam, joel

### DIFF
--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		6E887936278EB7A9001DE591 /* KoreanEntryListTableViewDataSoruce.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E887935278EB7A9001DE591 /* KoreanEntryListTableViewDataSoruce.swift */; };
 		6E887938278EB7D5001DE591 /* KoreanEntryListTableViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E887937278EB7D5001DE591 /* KoreanEntryListTableViewDelegate.swift */; };
+		6E887988279568DB001DE591 /* Int+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E887987279568DB001DE591 /* Int+Extension.swift */; };
 		6EA7899E278C167900064B4C /* KoreanEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA7899D278C167900064B4C /* KoreanEntry.swift */; };
 		6EA789A0278C168500064B4C /* UniversalExposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA7899F278C168500064B4C /* UniversalExposition.swift */; };
 		6EA789A5278C174D00064B4C /* koreanEntryMock.json in Resources */ = {isa = PBXBuildFile; fileRef = 6EA789A4278C174D00064B4C /* koreanEntryMock.json */; };
@@ -33,6 +34,7 @@
 /* Begin PBXFileReference section */
 		6E887935278EB7A9001DE591 /* KoreanEntryListTableViewDataSoruce.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KoreanEntryListTableViewDataSoruce.swift; sourceTree = "<group>"; };
 		6E887937278EB7D5001DE591 /* KoreanEntryListTableViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KoreanEntryListTableViewDelegate.swift; sourceTree = "<group>"; };
+		6E887987279568DB001DE591 /* Int+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int+Extension.swift"; sourceTree = "<group>"; };
 		6EA7899D278C167900064B4C /* KoreanEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KoreanEntry.swift; sourceTree = "<group>"; };
 		6EA7899F278C168500064B4C /* UniversalExposition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UniversalExposition.swift; sourceTree = "<group>"; };
 		6EA789A4278C174D00064B4C /* koreanEntryMock.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = koreanEntryMock.json; sourceTree = "<group>"; };
@@ -116,6 +118,7 @@
 			isa = PBXGroup;
 			children = (
 				C23E4AB7278D1222004B7270 /* Constant.swift */,
+				6E887987279568DB001DE591 /* Int+Extension.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -226,6 +229,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				6E887938278EB7D5001DE591 /* KoreanEntryListTableViewDelegate.swift in Sources */,
+				6E887988279568DB001DE591 /* Int+Extension.swift in Sources */,
 				C23E4ABA278D123F004B7270 /* ExpositionRepositoryDummyImpl.swift in Sources */,
 				C79FF4B92589F401005FB0FD /* ExpositionViewController.swift in Sources */,
 				C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */,

--- a/Expo1900/Expo1900/Common/Constant.swift
+++ b/Expo1900/Expo1900/Common/Constant.swift
@@ -13,4 +13,5 @@ struct Constant {
     static let showDetailKoreanEntryNotification = "showDetailKoreanEntry"
     static let KoreanEntryDetailViewControllerIdentifier = "Detail"
     static let selectedIndexPathRow = "selectedIndexPathRow"
+    static let screenRotatingNotification = "UIDeviceOrientationDidChangeNotification"
 }

--- a/Expo1900/Expo1900/Common/Int+Extension.swift
+++ b/Expo1900/Expo1900/Common/Int+Extension.swift
@@ -1,0 +1,20 @@
+//
+//  Int+Extension.swift
+//  Expo1900
+//
+//  Created by 이승주 on 2022/01/17.
+//
+
+import Foundation
+
+extension Int {
+    func numberToDecimalString() -> String {
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .decimal
+        guard let visitors = numberFormatter.string(from: NSNumber(value: self)) else {
+            return "0"
+        }
+        
+        return visitors
+    }
+}

--- a/Expo1900/Expo1900/Controllers/ExpositionViewController.swift
+++ b/Expo1900/Expo1900/Controllers/ExpositionViewController.swift
@@ -49,13 +49,28 @@ class ExpositionViewController: UIViewController {
     }
     
     private func configureUI() {
-        self.titleLabel.text = self.universalExposition?.title
-        self.visitorsLabel.text = "\(self.universalExposition?.visitors ?? 0) 명"
-        self.locationLabel.text = self.universalExposition?.location
-        self.durationLabel.text = self.universalExposition?.duration
-        self.descriptionLabel.text = self.universalExposition?.description
+        guard let universalExposition = self.universalExposition else {
+            return
+        }
+
+        self.titleLabel.text = universalExposition.title
+        self.visitorsLabel.text = "\(universalExposition.visitors.numberToDecimalString()) 명"
+        self.locationLabel.text = universalExposition.location
+        self.durationLabel.text = universalExposition.duration
+        self.descriptionLabel.text = universalExposition.description
         
-        showListButton.titleLabel?.adjustsFontForContentSizeCategory = true
+        guard let titleLabel = self.showListButton.titleLabel else {
+            return
+        }
+        
+        titleLabel.adjustsFontForContentSizeCategory = true
+        titleLabel.numberOfLines = 0
+        titleLabel.topAnchor.constraint(
+            equalTo: self.showListButton.topAnchor
+        ).isActive = true
+        titleLabel.bottomAnchor.constraint(
+            equalTo: self.showListButton.bottomAnchor
+        ).isActive = true
     }
     
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {

--- a/Expo1900/Expo1900/Controllers/ExpositionViewController.swift
+++ b/Expo1900/Expo1900/Controllers/ExpositionViewController.swift
@@ -14,6 +14,7 @@ class ExpositionViewController: UIViewController {
     @IBOutlet weak var locationLabel: UILabel!
     @IBOutlet weak var durationLabel: UILabel!
     @IBOutlet weak var descriptionLabel: UILabel!
+    @IBOutlet weak var showListButton: UIButton!
     
     private var api: ExpositionRepository?
     private var universalExposition: UniversalExposition? {
@@ -53,6 +54,8 @@ class ExpositionViewController: UIViewController {
         self.locationLabel.text = self.universalExposition?.location
         self.durationLabel.text = self.universalExposition?.duration
         self.descriptionLabel.text = self.universalExposition?.description
+        
+        showListButton.titleLabel?.adjustsFontForContentSizeCategory = true
     }
     
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {

--- a/Expo1900/Expo1900/Controllers/KoreanEntryDetailViewController.swift
+++ b/Expo1900/Expo1900/Controllers/KoreanEntryDetailViewController.swift
@@ -8,21 +8,96 @@
 import UIKit
 
 class KoreanEntryDetailViewController: UIViewController {
-
+    
+    @IBOutlet weak var koreanEntryStackView: UIStackView!
     @IBOutlet weak var koreanEntryImageView: UIImageView!
     @IBOutlet weak var descriptionLabel: UILabel!
+    @IBOutlet weak var landscapeImageContainerView: UIView!
+    @IBOutlet weak var landsacpeContainerWidthConstraint: NSLayoutConstraint!
+    
+    private lazy var imageViewHeightConstraint: NSLayoutConstraint = {
+        self.koreanEntryImageView.heightAnchor.constraint(
+            lessThanOrEqualTo: view.safeAreaLayoutGuide.heightAnchor,
+            multiplier: 0.3
+        )
+    }()
+    
+    private lazy var imageViewConstraints: [NSLayoutConstraint?] = {
+        
+        self.koreanEntryImageView.translatesAutoresizingMaskIntoConstraints = false
+        
+        let constraints = [
+            self.koreanEntryImageView.leadingAnchor.constraint(
+                equalTo: self.landscapeImageContainerView.leadingAnchor,
+                constant: 10
+            ),
+            self.koreanEntryImageView.trailingAnchor.constraint(
+                equalTo: self.landscapeImageContainerView.trailingAnchor,
+                constant: 10
+            ),
+            self.koreanEntryImageView.centerYAnchor.constraint(
+                equalTo: self.landscapeImageContainerView.centerYAnchor
+            ),
+            self.koreanEntryImageView.widthAnchor.constraint(
+                equalTo: self.view.safeAreaLayoutGuide.widthAnchor,
+                multiplier: 0.3
+            )
+        ]
+        return constraints
+    }()
     
     var koreanEntry: KoreanEntry?
     
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        guard let koreanEntry = koreanEntry else {
+        self.setUpNotificationObserver()
+        self.configureUI()
+    }
+    
+    private func setUpNotificationObserver() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(self.detectOrientation),
+            name: NSNotification.Name(Constant.screenRotatingNotification),
+            object: nil
+        )
+    }
+    
+    private func configureUI() {
+        guard let koreanEntry = self.koreanEntry else {
             return
         }
         
         self.navigationItem.title = koreanEntry.name
-        koreanEntryImageView.image = UIImage(named: koreanEntry.imageName)
-        descriptionLabel.text = koreanEntry.description
+        self.koreanEntryImageView.image = UIImage(named: koreanEntry.imageName)
+        self.descriptionLabel.text = koreanEntry.description
+    }
+    
+    @objc func detectOrientation() {
+        switch UIDevice.current.orientation {
+        case .landscapeLeft, .landscapeRight:
+            self.configureLandscapeLayout()
+        case .portrait:
+            self.configurePortraitLayout()
+        default:
+            break
+        }
+    }
+    
+    private func configureLandscapeLayout() {
+        self.koreanEntryImageView.removeFromSuperview()
+        self.landscapeImageContainerView.addSubview(self.koreanEntryImageView)
+        self.imageViewConstraints.forEach { $0?.isActive = true }
+        self.imageViewHeightConstraint.isActive = false
+        self.landsacpeContainerWidthConstraint.priority = .defaultLow
+    }
+    
+    private func configurePortraitLayout() {
+        self.imageViewConstraints.forEach { $0?.isActive = false }
+        self.koreanEntryImageView.removeFromSuperview()
+        self.landscapeImageContainerView.setNeedsLayout()
+        self.koreanEntryStackView.insertArrangedSubview(self.koreanEntryImageView, at: 0)
+        self.imageViewHeightConstraint.isActive = true
+        self.landsacpeContainerWidthConstraint.priority = .defaultHigh
     }
 }

--- a/Expo1900/Expo1900/Controllers/KoreanEntryDetailViewController.swift
+++ b/Expo1900/Expo1900/Controllers/KoreanEntryDetailViewController.swift
@@ -54,6 +54,15 @@ class KoreanEntryDetailViewController: UIViewController {
         self.configureUI()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        let bounds: CGRect = UIScreen.main.bounds
+        if bounds.width > bounds.height {
+            self.configureLandscapeLayout()
+        }
+    }
+    
     private func setUpNotificationObserver() {
         NotificationCenter.default.addObserver(
             self,

--- a/Expo1900/Expo1900/Controllers/KoreanEntryDetailViewController.swift
+++ b/Expo1900/Expo1900/Controllers/KoreanEntryDetailViewController.swift
@@ -21,6 +21,7 @@ class KoreanEntryDetailViewController: UIViewController {
             return
         }
         
+        self.navigationItem.title = koreanEntry.name
         koreanEntryImageView.image = UIImage(named: koreanEntry.imageName)
         descriptionLabel.text = koreanEntry.description
     }

--- a/Expo1900/Expo1900/Controllers/KoreanEntryDetailViewController.swift
+++ b/Expo1900/Expo1900/Controllers/KoreanEntryDetailViewController.swift
@@ -104,7 +104,6 @@ class KoreanEntryDetailViewController: UIViewController {
     private func configurePortraitLayout() {
         self.imageViewConstraints.forEach { $0?.isActive = false }
         self.koreanEntryImageView.removeFromSuperview()
-        self.landscapeImageContainerView.setNeedsLayout()
         self.koreanEntryStackView.insertArrangedSubview(self.koreanEntryImageView, at: 0)
         self.imageViewHeightConstraint.isActive = true
         self.landsacpeContainerWidthConstraint.priority = .defaultHigh

--- a/Expo1900/Expo1900/Resources/universalExpositionMock.json
+++ b/Expo1900/Expo1900/Resources/universalExpositionMock.json
@@ -1,5 +1,5 @@
 {
-    "title":"파리 만국박람회 1900(L'Exposition de Paris 1900)",
+    "title":"파리 만국박람회 1900\n(L'Exposition de Paris 1900)",
     "visitors":48130300,
     "location":"프랑스 파리",
     "duration":"1900. 04. 14 - 1900. 11. 12",

--- a/Expo1900/Expo1900/Views/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/Views/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Prp-W7-1Bz">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Prp-W7-1Bz">
     <device id="retina6_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -133,6 +133,7 @@
                                                 </subviews>
                                                 <constraints>
                                                     <constraint firstItem="biO-w6-Pzc" firstAttribute="width" secondItem="AzL-5r-FGH" secondAttribute="width" id="A7f-TO-8uR"/>
+                                                    <constraint firstItem="SrV-af-2yD" firstAttribute="width" relation="lessThanOrEqual" secondItem="ehQ-It-1il" secondAttribute="width" multiplier="0.5" id="Ve8-nJ-Vm0"/>
                                                 </constraints>
                                                 <directionalEdgeInsets key="directionalLayoutMargins" top="30" leading="8" bottom="8" trailing="8"/>
                                             </stackView>

--- a/Expo1900/Expo1900/Views/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/Views/Base.lproj/Main.storyboard
@@ -217,17 +217,24 @@
                         <rect key="frame" x="0.0" y="0.0" width="390" height="761"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cKR-V8-IM0" userLabel="Landscape Image Container View">
+                                <rect key="frame" x="0.0" y="88" width="0.0" height="673"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" priority="250" id="eNJ-TH-JMa"/>
+                                </constraints>
+                            </view>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6db-r4-DlN">
                                 <rect key="frame" x="0.0" y="88" width="390" height="673"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="csy-o6-rIW" customClass="Ko">
-                                        <rect key="frame" x="0.0" y="0.0" width="390" height="288"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="390" height="287"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="haegeum" translatesAutoresizingMaskIntoConstraints="NO" id="APd-JC-TJt">
-                                                <rect key="frame" x="15" y="30" width="360" height="203"/>
+                                                <rect key="frame" x="15" y="30" width="360" height="202"/>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="k65-1M-mEb">
-                                                <rect key="frame" x="15" y="241" width="360" height="17"/>
+                                                <rect key="frame" x="15" y="240" width="360" height="17"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -240,7 +247,6 @@
                                     <constraint firstItem="csy-o6-rIW" firstAttribute="height" secondItem="QcR-SC-qvN" secondAttribute="height" priority="1" id="5Xt-3W-ZDB"/>
                                     <constraint firstAttribute="bottom" secondItem="csy-o6-rIW" secondAttribute="bottom" id="BuH-AJ-FfZ"/>
                                     <constraint firstItem="csy-o6-rIW" firstAttribute="leading" secondItem="6db-r4-DlN" secondAttribute="leading" id="FTV-He-Nd0"/>
-                                    <constraint firstItem="APd-JC-TJt" firstAttribute="height" relation="lessThanOrEqual" secondItem="QcR-SC-qvN" secondAttribute="height" multiplier="0.3" constant="1" id="HhN-Ih-WOU"/>
                                     <constraint firstItem="csy-o6-rIW" firstAttribute="width" secondItem="6db-r4-DlN" secondAttribute="width" id="IG6-2B-CN0"/>
                                     <constraint firstAttribute="trailing" secondItem="csy-o6-rIW" secondAttribute="trailing" id="LOA-rb-aac"/>
                                     <constraint firstItem="csy-o6-rIW" firstAttribute="top" secondItem="6db-r4-DlN" secondAttribute="top" id="cBe-vC-9dl"/>
@@ -252,16 +258,24 @@
                         <viewLayoutGuide key="safeArea" id="NuW-4E-nIv"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="6db-r4-DlN" firstAttribute="leading" secondItem="NuW-4E-nIv" secondAttribute="leading" id="8B1-GL-rZU"/>
+                            <constraint firstItem="APd-JC-TJt" firstAttribute="width" secondItem="NuW-4E-nIv" secondAttribute="width" multiplier="0.3" priority="749" id="9FQ-Sv-VrW"/>
                             <constraint firstItem="6db-r4-DlN" firstAttribute="top" secondItem="NuW-4E-nIv" secondAttribute="top" id="GSJ-OV-iSo"/>
+                            <constraint firstItem="cKR-V8-IM0" firstAttribute="trailing" secondItem="6db-r4-DlN" secondAttribute="leading" id="OcB-l3-MYb"/>
+                            <constraint firstItem="cKR-V8-IM0" firstAttribute="leading" secondItem="NuW-4E-nIv" secondAttribute="leading" id="Zn9-5x-mzu"/>
                             <constraint firstItem="NuW-4E-nIv" firstAttribute="trailing" secondItem="6db-r4-DlN" secondAttribute="trailing" id="aWN-48-BDs"/>
                             <constraint firstItem="NuW-4E-nIv" firstAttribute="bottom" secondItem="6db-r4-DlN" secondAttribute="bottom" id="coY-eZ-P2I"/>
+                            <constraint firstItem="NuW-4E-nIv" firstAttribute="bottom" secondItem="cKR-V8-IM0" secondAttribute="bottom" id="hyl-fP-la6"/>
+                            <constraint firstItem="cKR-V8-IM0" firstAttribute="top" secondItem="NuW-4E-nIv" secondAttribute="top" id="q7e-R9-X0a"/>
+                            <constraint firstItem="APd-JC-TJt" firstAttribute="height" relation="lessThanOrEqual" secondItem="NuW-4E-nIv" secondAttribute="height" multiplier="0.3" id="xZx-hR-Mj1"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="Yc6-2h-JI7"/>
                     <connections>
                         <outlet property="descriptionLabel" destination="k65-1M-mEb" id="vH6-rw-hfN"/>
                         <outlet property="koreanEntryImageView" destination="APd-JC-TJt" id="I6r-Jq-5QK"/>
+                        <outlet property="koreanEntryStackView" destination="csy-o6-rIW" id="kAc-qn-yce"/>
+                        <outlet property="landsacpeContainerWidthConstraint" destination="eNJ-TH-JMa" id="hAl-dh-OBD"/>
+                        <outlet property="landscapeImageContainerView" destination="cKR-V8-IM0" id="PDM-vM-2e6"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Fsb-AL-gIh" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/Expo1900/Expo1900/Views/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/Views/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Prp-W7-1Bz">
-    <device id="retina6_1" orientation="portrait" appearance="light"/>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Prp-W7-1Bz">
+    <device id="retina6_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -14,7 +14,7 @@
             <objects>
                 <navigationController id="Prp-W7-1Bz" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="7gm-56-WLe">
-                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <rect key="frame" x="0.0" y="44" width="390" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
@@ -30,35 +30,35 @@
             <objects>
                 <viewController id="BYZ-38-t0r" customClass="ExpositionViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="S3a-Jp-aSE">
-                                <rect key="frame" x="0.0" y="88" width="414" height="774"/>
+                                <rect key="frame" x="0.0" y="88" width="390" height="722"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="I2c-Ik-bOM">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="1553.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="390" height="1629"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ivb-ib-KvK" userLabel="TitleLabel">
-                                                <rect key="frame" x="184" y="30" width="46.5" height="30"/>
+                                                <rect key="frame" x="172" y="30" width="46.333333333333343" height="30"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="poster" translatesAutoresizingMaskIntoConstraints="NO" id="GQl-Rx-yuD">
-                                                <rect key="frame" x="124" y="72" width="166" height="200"/>
+                                                <rect key="frame" x="117" y="72" width="156" height="200"/>
                                             </imageView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="3" translatesAutoresizingMaskIntoConstraints="NO" id="ZVj-QN-7og" userLabel="Visitors">
-                                                <rect key="frame" x="160" y="284" width="94.5" height="20.5"/>
+                                                <rect key="frame" x="148" y="284" width="94.333333333333314" height="20.333333333333314"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="방문객 :" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ch4-Va-oDa" userLabel="방문객">
-                                                        <rect key="frame" x="0.0" y="0.0" width="53.5" height="20.5"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="53.333333333333336" height="20.333333333333332"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="200명" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hAy-fL-Ovf" userLabel="VisitorNumLabel">
-                                                        <rect key="frame" x="56.5" y="0.0" width="38" height="20.5"/>
+                                                        <rect key="frame" x="56.333333333333343" y="0.0" width="38" height="20.333333333333332"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -66,16 +66,16 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="3" translatesAutoresizingMaskIntoConstraints="NO" id="3lu-cZ-cCb" userLabel="Location">
-                                                <rect key="frame" x="148.5" y="316.5" width="117.5" height="20.5"/>
+                                                <rect key="frame" x="136.66666666666666" y="316.33333333333331" width="117" height="20.333333333333314"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="개최지 :" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="s5q-f7-eGW" userLabel="개최지">
-                                                        <rect key="frame" x="0.0" y="0.0" width="53.5" height="20.5"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="53.333333333333336" height="20.333333333333332"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="프랑스파리" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pX3-NK-Q0u" userLabel="LocationLabel">
-                                                        <rect key="frame" x="56.5" y="0.0" width="61" height="20.5"/>
+                                                        <rect key="frame" x="56.333333333333343" y="0.0" width="60.666666666666657" height="20.333333333333332"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -83,16 +83,16 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="3" translatesAutoresizingMaskIntoConstraints="NO" id="GgE-iE-hOX" userLabel="Duration">
-                                                <rect key="frame" x="85" y="349" width="244" height="20.5"/>
+                                                <rect key="frame" x="73.333333333333329" y="348.66666666666669" width="243.66666666666669" height="20.333333333333314"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="개최 기간 :" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SmF-6S-5dk" userLabel="개최 기간">
-                                                        <rect key="frame" x="0.0" y="0.0" width="72.5" height="20.5"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="72.333333333333329" height="20.333333333333332"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1900. 04. 14 - 1900. 11. 12" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="q68-u7-7ea" userLabel="DurationLabel">
-                                                        <rect key="frame" x="75.5" y="0.0" width="168.5" height="20.5"/>
+                                                        <rect key="frame" x="75.333333333333329" y="0.0" width="168.33333333333337" height="20.333333333333332"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -100,23 +100,23 @@
                                                 </subviews>
                                             </stackView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XFg-R8-Zpa" userLabel="DescriptionLabel">
-                                                <rect key="frame" x="15" y="381.5" width="384" height="1062"/>
+                                                <rect key="frame" x="15" y="381" width="360" height="1138"/>
                                                 <string key="text">1900년 파리 만국박람회(지금의 세계 박람회[World’s Fair/Exposition/Expo])는 지난 세기를 기념하고 다음 세기를 향한 발전을 가속하자는 의미에서 1900년 4월 14일부터 11월 12일까지 프랑스 파리에서 열린 세계 박람회였다. 이 박람회에서 널리 선보였던 건축 양식이 바로 '아르누보'였다. 총 관람객수가 5000만 명에 달한 1900년 세계 박람회에서는 수많은 기계와 발명품, 그리고 건축물들이 전시됐는데 그 중에는 그랑드 루 드 파리 대관람차, 마트료시카 인형, 디젤 엔진, 유성영화, 에스컬레이터, 텔레그라폰 (최초의 자석식 녹음기) 등 지금도 널리 알려져 있는 것들도 등장했다.\n\n프랑스는 1855년에도 만국 박람회를 개최한 전력이 있었는데 전쟁 후 국가의 자부심과 신념을 다시 세우고자 하는 욕구로부터 비롯된 것이었다. 1900년 박람회가 성공을 거둔 것도 전후 국가 부흥이라는 똑같은 주제에 따른 것이었다. 1900년 파리 세계 박람회가 개최되기 8년 전인 1892년, 프랑스 정부는 새 세기의 도래를 환영하고 축하하는 박람회를 열 것이라고 발표했다.\n\n프랑스는 전세계 56개국에 초청장을 보냈고, 그 중 40개국이 수락하여 참가했다.참가국들이 이룬 것과 생활양식을 전시했다. 이 세계 박람회는 여러 가지 체험을 종합하여 익히도록 한 것이었다. 이를 통해 외국인들에게 각 국가들 간의 유사성은 물론 그 사이의 독특한 다양성을 깨닫도록 하는 기회를 제공했다. 또 새로운 문화를 경험하고 각국이 전시해 놓은 자국의 가치들을 전반적으로 더욱 이해할 수 있도록 했다. 이러한 상호 이해의 환경이 전쟁 시대 이후 필요하다고 여겨졌던 문화적 관용을 늘리는데 한몫하도록 했다. 박람회 개최 소식이 발표되자 독일에서 처음으로 열린 국제 박람회에 쏠렸던 관심은 풀리고 박람회 개최에 대한 호응이 어마어마하게 쏟아졌다. 박람회에 대한 지지도 대단해서 각국에서는 즉시 자국 전시관 계획을 세우기 시작했다. \n\n파리 만국박람회가 개최된 1900년 4월 14일부터 11월 12일까지 프랑스 파리에는 대한제국의 문화와 문물이 전시된 한국관이 세워졌습니다. 한국관은 경복궁의 근정전을 재현한 주전시관과 옛 국왕들의 위패를 모셔놓은 사당을 별채로 구성되었는데, 이는 우리 건축의 아름다움을 세계에 알린 첫 건축물이 되었습니다. 특히 만국박 람회의 대한제국관을 묘사한 프랑스 잡지 ‘르 프티 주르날(Le Petit Journal)’은 태극기를 표시해 당당하게 대한 제국의 상징으로 많은 관심을 받을 수 있었습니다.\n\n한국관의 전시품은 정확하게 어떤 것이 전시되었는지 알 수는 없지만 대한제국과 프랑스 정부간에 오고 간 문 서를 통해 짐작할 수 있습니다. 대한제국 정부는 우리의 다양한 전통문화를 나타내는 비단, 놋그릇, 도자기, 칠 보 등의 공예품을 제공한 것으로 보이며, 이 밖에도 악기, 옷, 가구, 예술품 등도 있었다고 합니다. 만국박람회는 참가한 나라들의 산업을 소개하는 역할을 했고, 전시는 물론 시상도 했는데 대한제국은 식물성 농업식품 분야 에서 그랑프리(대상)을 수상하였다고 합니다.\n\n1900년 11월 12일 파리 만국박람회가 폐막된 후 한국관에 출품되었던 전시품들은 다시 본국으로 돌아오지 못하고 대부분 현지에 기증되었는데, 이는 일종의 관례이기도 했지만 본국으로 회수하는데 드는 과도한 운송비용 때문이기도 했습니다.\n\n현재 이 전시품들은 프랑스에 있는 국립공예박물관, 국립예술직업전문학교, 국립음악원 음악박물관, 국립 기메 아시아박물관 등에 소장되어있습니다. 특히 전시품으로 기증된 악기들 중 해금은 현존하는 해금 가운데 가장 오래된 것으로 추정되고 있다고도 합니다. 우리의 소중한 역사적 유물을 멀리 두고 올 수 밖에 없던 상황이 안타깝게 느껴집니다.\n\n작고 힘없는 나라 대한제국이 세계 강국들이 모인 만국박람회에 참가한다는 자체가 불가능하다는 의견이 지배 적이었지만 1900년 프랑스 파리에 근정전을 본뜬 한국관이 우뚝 세워졌습니다. 그 존재만으로 독립된 나라임을 세계에 알리고자 했던 목표는 이루어진 것 같습니다. 그러나 안타깝게도 그로부터 5년 후인 1905년 을사늑약이 체결되었고, 대한제국은 독립국가로서 세계에서 점점 잊혀져 갔습니다.</string>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" alignment="center" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="ehQ-It-1il">
-                                                <rect key="frame" x="15" y="1455.5" width="384" height="68"/>
+                                                <rect key="frame" x="15" y="1531" width="360" height="68"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="flag" translatesAutoresizingMaskIntoConstraints="NO" id="biO-w6-Pzc">
-                                                        <rect key="frame" x="8" y="30" width="89.5" height="30"/>
+                                                        <rect key="frame" x="8" y="30" width="77.666666666666671" height="30"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="30" id="DP2-Tj-2Dj"/>
                                                         </constraints>
                                                     </imageView>
                                                     <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="SrV-af-2yD">
-                                                        <rect key="frame" x="127.5" y="30.5" width="129" height="29"/>
+                                                        <rect key="frame" x="115.66666666666666" y="30.666666666666742" width="129" height="29"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                                         <state key="normal" title="한국의 출품작 보러가기"/>
@@ -125,7 +125,7 @@
                                                         </connections>
                                                     </button>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="flag" translatesAutoresizingMaskIntoConstraints="NO" id="AzL-5r-FGH">
-                                                        <rect key="frame" x="286.5" y="30" width="89.5" height="30"/>
+                                                        <rect key="frame" x="274.66666666666669" y="30" width="77.333333333333314" height="30"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="30" id="TdK-CY-Vjb"/>
                                                         </constraints>
@@ -181,11 +181,11 @@
             <objects>
                 <viewController id="oBB-Qy-5oF" customClass="KoreanEntryListViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="xgV-ra-2Dd">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="813"/>
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="761"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="nhJ-3o-wXe">
-                                <rect key="frame" x="0.0" y="88" width="414" height="725"/>
+                                <rect key="frame" x="0.0" y="88" width="390" height="673"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </tableView>
                         </subviews>
@@ -214,31 +214,33 @@
             <objects>
                 <viewController id="td0-3h-bZd" customClass="KoreanEntryDetailViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="qh4-V3-ia9">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="813"/>
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="761"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6db-r4-DlN">
-                                <rect key="frame" x="0.0" y="88" width="414" height="725"/>
+                                <rect key="frame" x="0.0" y="88" width="390" height="673"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="csy-o6-rIW" customClass="Ko">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="219"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="390" height="288"/>
                                         <subviews>
-                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="folds" translatesAutoresizingMaskIntoConstraints="NO" id="APd-JC-TJt">
-                                                <rect key="frame" x="0.0" y="0.0" width="414" height="194"/>
+                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="haegeum" translatesAutoresizingMaskIntoConstraints="NO" id="APd-JC-TJt">
+                                                <rect key="frame" x="15" y="30" width="360" height="203"/>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="k65-1M-mEb">
-                                                <rect key="frame" x="0.0" y="202" width="414" height="17"/>
+                                                <rect key="frame" x="15" y="241" width="360" height="17"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                         </subviews>
+                                        <directionalEdgeInsets key="directionalLayoutMargins" top="30" leading="15" bottom="30" trailing="15"/>
                                     </stackView>
                                 </subviews>
                                 <constraints>
                                     <constraint firstItem="csy-o6-rIW" firstAttribute="height" secondItem="QcR-SC-qvN" secondAttribute="height" priority="1" id="5Xt-3W-ZDB"/>
                                     <constraint firstAttribute="bottom" secondItem="csy-o6-rIW" secondAttribute="bottom" id="BuH-AJ-FfZ"/>
                                     <constraint firstItem="csy-o6-rIW" firstAttribute="leading" secondItem="6db-r4-DlN" secondAttribute="leading" id="FTV-He-Nd0"/>
+                                    <constraint firstItem="APd-JC-TJt" firstAttribute="height" relation="lessThanOrEqual" secondItem="QcR-SC-qvN" secondAttribute="height" multiplier="0.3" constant="1" id="HhN-Ih-WOU"/>
                                     <constraint firstItem="csy-o6-rIW" firstAttribute="width" secondItem="6db-r4-DlN" secondAttribute="width" id="IG6-2B-CN0"/>
                                     <constraint firstAttribute="trailing" secondItem="csy-o6-rIW" secondAttribute="trailing" id="LOA-rb-aac"/>
                                     <constraint firstItem="csy-o6-rIW" firstAttribute="top" secondItem="6db-r4-DlN" secondAttribute="top" id="cBe-vC-9dl"/>
@@ -269,8 +271,8 @@
     </scenes>
     <resources>
         <image name="flag" width="851" height="567"/>
-        <image name="folds" width="293" height="194"/>
-        <image name="poster" width="144" height="200"/>
+        <image name="haegeum" width="952" height="1430"/>
+        <image name="poster" width="143.66667175292969" height="200"/>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/Expo1900/Expo1900/Views/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/Views/Base.lproj/Main.storyboard
@@ -36,20 +36,20 @@
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="S3a-Jp-aSE">
                                 <rect key="frame" x="0.0" y="88" width="414" height="774"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="I2c-Ik-bOM">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="1854.5"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="I2c-Ik-bOM">
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="1553.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ivb-ib-KvK" userLabel="TitleLabel">
-                                                <rect key="frame" x="184" y="0.0" width="46.5" height="30"/>
+                                                <rect key="frame" x="184" y="30" width="46.5" height="30"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="poster" translatesAutoresizingMaskIntoConstraints="NO" id="GQl-Rx-yuD">
-                                                <rect key="frame" x="124" y="38" width="166" height="200"/>
+                                                <rect key="frame" x="124" y="72" width="166" height="200"/>
                                             </imageView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="3" translatesAutoresizingMaskIntoConstraints="NO" id="ZVj-QN-7og" userLabel="Visitors">
-                                                <rect key="frame" x="160" y="246" width="94.5" height="20.5"/>
+                                                <rect key="frame" x="160" y="284" width="94.5" height="20.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="방문객 :" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ch4-Va-oDa" userLabel="방문객">
                                                         <rect key="frame" x="0.0" y="0.0" width="53.5" height="20.5"/>
@@ -66,7 +66,7 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="3" translatesAutoresizingMaskIntoConstraints="NO" id="3lu-cZ-cCb" userLabel="Location">
-                                                <rect key="frame" x="148.5" y="274.5" width="117.5" height="20.5"/>
+                                                <rect key="frame" x="148.5" y="316.5" width="117.5" height="20.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="개최지 :" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="s5q-f7-eGW" userLabel="개최지">
                                                         <rect key="frame" x="0.0" y="0.0" width="53.5" height="20.5"/>
@@ -83,7 +83,7 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="3" translatesAutoresizingMaskIntoConstraints="NO" id="GgE-iE-hOX" userLabel="Duration">
-                                                <rect key="frame" x="85" y="303" width="244" height="20.5"/>
+                                                <rect key="frame" x="85" y="349" width="244" height="20.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="개최 기간 :" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SmF-6S-5dk" userLabel="개최 기간">
                                                         <rect key="frame" x="0.0" y="0.0" width="72.5" height="20.5"/>
@@ -99,21 +99,25 @@
                                                     </label>
                                                 </subviews>
                                             </stackView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="characterWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XFg-R8-Zpa" userLabel="DescriptionLabel">
-                                                <rect key="frame" x="0.0" y="331.5" width="414" height="948"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XFg-R8-Zpa" userLabel="DescriptionLabel">
+                                                <rect key="frame" x="15" y="381.5" width="384" height="1062"/>
                                                 <string key="text">1900년 파리 만국박람회(지금의 세계 박람회[World’s Fair/Exposition/Expo])는 지난 세기를 기념하고 다음 세기를 향한 발전을 가속하자는 의미에서 1900년 4월 14일부터 11월 12일까지 프랑스 파리에서 열린 세계 박람회였다. 이 박람회에서 널리 선보였던 건축 양식이 바로 '아르누보'였다. 총 관람객수가 5000만 명에 달한 1900년 세계 박람회에서는 수많은 기계와 발명품, 그리고 건축물들이 전시됐는데 그 중에는 그랑드 루 드 파리 대관람차, 마트료시카 인형, 디젤 엔진, 유성영화, 에스컬레이터, 텔레그라폰 (최초의 자석식 녹음기) 등 지금도 널리 알려져 있는 것들도 등장했다.\n\n프랑스는 1855년에도 만국 박람회를 개최한 전력이 있었는데 전쟁 후 국가의 자부심과 신념을 다시 세우고자 하는 욕구로부터 비롯된 것이었다. 1900년 박람회가 성공을 거둔 것도 전후 국가 부흥이라는 똑같은 주제에 따른 것이었다. 1900년 파리 세계 박람회가 개최되기 8년 전인 1892년, 프랑스 정부는 새 세기의 도래를 환영하고 축하하는 박람회를 열 것이라고 발표했다.\n\n프랑스는 전세계 56개국에 초청장을 보냈고, 그 중 40개국이 수락하여 참가했다.참가국들이 이룬 것과 생활양식을 전시했다. 이 세계 박람회는 여러 가지 체험을 종합하여 익히도록 한 것이었다. 이를 통해 외국인들에게 각 국가들 간의 유사성은 물론 그 사이의 독특한 다양성을 깨닫도록 하는 기회를 제공했다. 또 새로운 문화를 경험하고 각국이 전시해 놓은 자국의 가치들을 전반적으로 더욱 이해할 수 있도록 했다. 이러한 상호 이해의 환경이 전쟁 시대 이후 필요하다고 여겨졌던 문화적 관용을 늘리는데 한몫하도록 했다. 박람회 개최 소식이 발표되자 독일에서 처음으로 열린 국제 박람회에 쏠렸던 관심은 풀리고 박람회 개최에 대한 호응이 어마어마하게 쏟아졌다. 박람회에 대한 지지도 대단해서 각국에서는 즉시 자국 전시관 계획을 세우기 시작했다. \n\n파리 만국박람회가 개최된 1900년 4월 14일부터 11월 12일까지 프랑스 파리에는 대한제국의 문화와 문물이 전시된 한국관이 세워졌습니다. 한국관은 경복궁의 근정전을 재현한 주전시관과 옛 국왕들의 위패를 모셔놓은 사당을 별채로 구성되었는데, 이는 우리 건축의 아름다움을 세계에 알린 첫 건축물이 되었습니다. 특히 만국박 람회의 대한제국관을 묘사한 프랑스 잡지 ‘르 프티 주르날(Le Petit Journal)’은 태극기를 표시해 당당하게 대한 제국의 상징으로 많은 관심을 받을 수 있었습니다.\n\n한국관의 전시품은 정확하게 어떤 것이 전시되었는지 알 수는 없지만 대한제국과 프랑스 정부간에 오고 간 문 서를 통해 짐작할 수 있습니다. 대한제국 정부는 우리의 다양한 전통문화를 나타내는 비단, 놋그릇, 도자기, 칠 보 등의 공예품을 제공한 것으로 보이며, 이 밖에도 악기, 옷, 가구, 예술품 등도 있었다고 합니다. 만국박람회는 참가한 나라들의 산업을 소개하는 역할을 했고, 전시는 물론 시상도 했는데 대한제국은 식물성 농업식품 분야 에서 그랑프리(대상)을 수상하였다고 합니다.\n\n1900년 11월 12일 파리 만국박람회가 폐막된 후 한국관에 출품되었던 전시품들은 다시 본국으로 돌아오지 못하고 대부분 현지에 기증되었는데, 이는 일종의 관례이기도 했지만 본국으로 회수하는데 드는 과도한 운송비용 때문이기도 했습니다.\n\n현재 이 전시품들은 프랑스에 있는 국립공예박물관, 국립예술직업전문학교, 국립음악원 음악박물관, 국립 기메 아시아박물관 등에 소장되어있습니다. 특히 전시품으로 기증된 악기들 중 해금은 현존하는 해금 가운데 가장 오래된 것으로 추정되고 있다고도 합니다. 우리의 소중한 역사적 유물을 멀리 두고 올 수 밖에 없던 상황이 안타깝게 느껴집니다.\n\n작고 힘없는 나라 대한제국이 세계 강국들이 모인 만국박람회에 참가한다는 자체가 불가능하다는 의견이 지배 적이었지만 1900년 프랑스 파리에 근정전을 본뜬 한국관이 우뚝 세워졌습니다. 그 존재만으로 독립된 나라임을 세계에 알리고자 했던 목표는 이루어진 것 같습니다. 그러나 안타깝게도 그로부터 5년 후인 1905년 을사늑약이 체결되었고, 대한제국은 독립국가로서 세계에서 점점 잊혀져 갔습니다.</string>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="ehQ-It-1il">
-                                                <rect key="frame" x="0.0" y="1287.5" width="414" height="567"/>
+                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" alignment="center" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="ehQ-It-1il">
+                                                <rect key="frame" x="15" y="1455.5" width="384" height="68"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="flag" translatesAutoresizingMaskIntoConstraints="NO" id="biO-w6-Pzc">
-                                                        <rect key="frame" x="0.0" y="0.0" width="130" height="567"/>
+                                                        <rect key="frame" x="8" y="30" width="89.5" height="30"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="30" id="DP2-Tj-2Dj"/>
+                                                        </constraints>
                                                     </imageView>
                                                     <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="SrV-af-2yD">
-                                                        <rect key="frame" x="138" y="268.5" width="138" height="30"/>
+                                                        <rect key="frame" x="127.5" y="30.5" width="129" height="29"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                                         <state key="normal" title="한국의 출품작 보러가기"/>
                                                         <connections>
@@ -121,14 +125,19 @@
                                                         </connections>
                                                     </button>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="flag" translatesAutoresizingMaskIntoConstraints="NO" id="AzL-5r-FGH">
-                                                        <rect key="frame" x="284" y="0.0" width="130" height="567"/>
+                                                        <rect key="frame" x="286.5" y="30" width="89.5" height="30"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="30" id="TdK-CY-Vjb"/>
+                                                        </constraints>
                                                     </imageView>
                                                 </subviews>
                                                 <constraints>
                                                     <constraint firstItem="biO-w6-Pzc" firstAttribute="width" secondItem="AzL-5r-FGH" secondAttribute="width" id="A7f-TO-8uR"/>
                                                 </constraints>
+                                                <directionalEdgeInsets key="directionalLayoutMargins" top="30" leading="8" bottom="8" trailing="8"/>
                                             </stackView>
                                         </subviews>
+                                        <directionalEdgeInsets key="directionalLayoutMargins" top="30" leading="15" bottom="30" trailing="15"/>
                                     </stackView>
                                 </subviews>
                                 <constraints>
@@ -158,6 +167,7 @@
                         <outlet property="durationLabel" destination="q68-u7-7ea" id="NIb-Od-TQK"/>
                         <outlet property="expositionImageView" destination="GQl-Rx-yuD" id="GXC-5C-dyK"/>
                         <outlet property="locationLabel" destination="pX3-NK-Q0u" id="cRD-rG-vYx"/>
+                        <outlet property="showListButton" destination="SrV-af-2yD" id="dcb-yG-E8F"/>
                         <outlet property="titleLabel" destination="Ivb-ib-KvK" id="kA5-gY-Wfl"/>
                         <outlet property="visitorsLabel" destination="hAy-fL-Ovf" id="vOT-Ue-Sag"/>
                     </connections>

--- a/Expo1900/Expo1900/Views/KoreanEntryTableViewCell.xib
+++ b/Expo1900/Expo1900/Views/KoreanEntryTableViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -18,10 +18,10 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="3" translatesAutoresizingMaskIntoConstraints="NO" id="waQ-AO-VYQ">
-                        <rect key="frame" x="20" y="11" width="125" height="128"/>
+                        <rect key="frame" x="20" y="11" width="133" height="128"/>
                         <subviews>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="aKi-YK-uKb">
-                                <rect key="frame" x="0.0" y="48.5" width="30.5" height="31"/>
+                                <rect key="frame" x="8" y="48" width="32" height="32"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="aKi-YK-uKb" secondAttribute="height" multiplier="1:1" id="QXk-RJ-mlH"/>
                                 </constraints>
@@ -31,21 +31,23 @@
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tKw-HU-KdS" userLabel="titleLabel">
-                                        <rect key="frame" x="0.0" y="0.0" width="59" height="30"/>
+                                        <rect key="frame" x="8" y="8" width="59" height="30"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="x5L-Bd-4ap" userLabel="contentLabel">
-                                        <rect key="frame" x="0.0" y="30" width="35.5" height="80"/>
+                                        <rect key="frame" x="8" y="38" width="35.5" height="64"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                 </subviews>
                                 <viewLayoutGuide key="safeArea" id="AmG-ym-baR"/>
+                                <directionalEdgeInsets key="directionalLayoutMargins" top="8" leading="8" bottom="8" trailing="8"/>
                             </stackView>
                         </subviews>
+                        <directionalEdgeInsets key="directionalLayoutMargins" top="8" leading="8" bottom="8" trailing="8"/>
                     </stackView>
                 </subviews>
                 <constraints>


### PR DESCRIPTION
# STEP 3
</br>

@dacodaco 
STEP3 PR 리뷰 요청드립니다 😀
</br>

# 구현한 것
 * 만국박람회 초기화면 한국의 출품작 보러가기 버튼 
     * 좌우 태극기 높이 설정 
     * 글씨크기 변동에 대응
 * 만국박람회 초기화면 만국박람회 방문객 표시
     *  천 단위로 , 표시 
 * 한국의 출품작 리스트 화면
     * 테이블뷰 아이템에 제약 추가(Margin)
* 출품작 디테일 화면 가로모드 대응
  * ScrollView의 leading과 빈 UIView(landscapeImageContainerView)의 trailing과 eqaulTo로 연결하여 가로 모드를 대응하였습니다.
  * 기존 세로모드는 스택뷰 안에 [이미지, 레이블]이 담겨 있고 landscapeImageContainerView 의 width는 0인 상태입니다.
  * 가로모드로 변경 시에
    1. 이미지뷰를 스택뷰에서 제거하고
    2. landscapeImageContainerView 에 이미지 뷰를 addSubview로 넣습니다.
    3. 그리고 이미지뷰와 landscapeImageContainerView 사이의 constraint들을 지정해 주고
    4. 세로모드에 적용되는 height constraint를 deactivate 해주고
    5. 기존에 landscapeImageContainerView 의 width가 0인 constraint의 prioirty를 low로 낮춰줘서 내부 컨텐츠 사이즈로 크기가 지정되도록 설정하였습니다.
  * 다시 세로모드 변경 시에
    1. 이미지뷰에 걸려있던 constraint들을 deactivate 해주고
    2. landscapeImageContainerView 에서 이미지 뷰를 제거하고
    3. stackview의 0번 위치에 이미지뷰를 삽입하고
    4. 세로모드에 적용되는 height constraint를 다시 activate 해주고
    5. 기존에 landscapeImageContainerView 의 width가 0인 constraint의 prioirty를 high로 높여줘서 width를 다시 0으로 맞췄습니다.

</br>

# 궁금한 것
1. STEP2에서 적용한 레파지토리 패턴 네이밍에 대해서
데이터를 fetch해오는 레파지토리(ExpositionRepository)를 만들고 이를 채택한 타입(서버, 내부 디비 등 실제로 데이터를 가져오는 곳)의 이름을 RepositoryImpl 이런식으로 작성하였습니다. 자바나 코틀린을 사용하는 곳에서는 Repository, RepositoryImpl이라고 네이밍 짓는 것이 흔한데, iOS & Swift에서도 이 네이밍을 사용하는게 괜찮을지와 이에 대한 네이밍 컨벤션이 있는지 궁금합니다!
</br>

2. 가로모드 및 세로모드 변경시에 위 5번 프로세스를 실행하지 않으면 아래와 같은 이미지로 보여집니다. UIView에 컨텐츠가 제거되면 width가 자동으로 0으로 줄어야할 것 같은데 왜 수행이 안되는지 혹시 알고 계시나요 ..?

<div><img src="https://media.discordapp.net/attachments/925604069140226069/932567345367511071/2022-01-17_6.27.36.png"  width="45%"></div>

# 마무리
항상 좋은 코드 리뷰와 피드백 감사드립니다!  🚀
짧지만 코다와 함께 고민해본 것이 많은 도움이 되었습니다! 앞으로도 잘 부탁드립니다!
