### PR TITLE
만국박람회 [STEP3] willy, hayden

### DIFF
--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		C2679EA3278EA0FF008C5013 /* HeritageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2679EA2278EA0FF008C5013 /* HeritageViewController.swift */; };
 		C2DBF1FA278D772600B764D2 /* HeritageTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2DBF1F9278D772600B764D2 /* HeritageTableViewController.swift */; };
 		C2DBF1FC278D775600B764D2 /* HeritageTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2DBF1FB278D775600B764D2 /* HeritageTableViewCell.swift */; };
+		C2F2175B27954A8600DA6965 /* MainNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2F2175A27954A8600DA6965 /* MainNavigationController.swift */; };
 		C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B42589F401005FB0FD /* AppDelegate.swift */; };
 		C79FF4B72589F401005FB0FD /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B62589F401005FB0FD /* SceneDelegate.swift */; };
 		C79FF4B92589F401005FB0FD /* ExpoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B82589F401005FB0FD /* ExpoViewController.swift */; };
@@ -30,6 +31,7 @@
 		C2679EA2278EA0FF008C5013 /* HeritageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeritageViewController.swift; sourceTree = "<group>"; };
 		C2DBF1F9278D772600B764D2 /* HeritageTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeritageTableViewController.swift; sourceTree = "<group>"; };
 		C2DBF1FB278D775600B764D2 /* HeritageTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeritageTableViewCell.swift; sourceTree = "<group>"; };
+		C2F2175A27954A8600DA6965 /* MainNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainNavigationController.swift; sourceTree = "<group>"; };
 		C79FF4B12589F401005FB0FD /* Expo1900.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Expo1900.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C79FF4B42589F401005FB0FD /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C79FF4B62589F401005FB0FD /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -57,6 +59,7 @@
 				C79FF4B82589F401005FB0FD /* ExpoViewController.swift */,
 				C2DBF1F9278D772600B764D2 /* HeritageTableViewController.swift */,
 				C2679EA2278EA0FF008C5013 /* HeritageViewController.swift */,
+				C2F2175A27954A8600DA6965 /* MainNavigationController.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -193,6 +196,7 @@
 				C79FF4B92589F401005FB0FD /* ExpoViewController.swift in Sources */,
 				C206CF0E278D68FC00911217 /* JsonParser.swift in Sources */,
 				C2130FCA278C1AF4009E2A8C /* InternationalExposition.swift in Sources */,
+				C2F2175B27954A8600DA6965 /* MainNavigationController.swift in Sources */,
 				C206CF10278D735800911217 /* Int+Extension.swift in Sources */,
 				C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */,
 				C2679EA3278EA0FF008C5013 /* HeritageViewController.swift in Sources */,
@@ -347,6 +351,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = WNXR5YEZYY;
 				INFOPLIST_FILE = Expo1900/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -365,6 +370,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 6YNXK75768;
 				INFOPLIST_FILE = Expo1900/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Expo1900/Expo1900/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="LHX-wM-DhN">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="LHX-wM-DhN">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -22,20 +22,20 @@
                                 <rect key="frame" x="0.0" y="44.5" width="414" height="159"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="I4V-2g-kqO" id="ooy-q4-nHK">
-                                    <rect key="frame" x="0.0" y="0.0" width="384.5" height="159"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="385.5" height="159"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="KiE-qJ-dhk">
-                                            <rect key="frame" x="10" y="10" width="364.5" height="139"/>
+                                            <rect key="frame" x="10" y="10" width="365.5" height="139"/>
                                             <subviews>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" adjustsImageSizeForAccessibilityContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="bjC-mT-xWS">
-                                                    <rect key="frame" x="0.0" y="30" width="79.5" height="79.5"/>
+                                                    <rect key="frame" x="0.0" y="33" width="73" height="73"/>
                                                     <constraints>
-                                                        <constraint firstAttribute="width" secondItem="bjC-mT-xWS" secondAttribute="height" multiplier="1:1" id="nQu-v5-WOx"/>
+                                                        <constraint firstAttribute="width" secondItem="bjC-mT-xWS" secondAttribute="height" multiplier="1:1" priority="999" id="nQu-v5-WOx"/>
                                                     </constraints>
                                                 </imageView>
                                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="lnw-ou-uV8">
-                                                    <rect key="frame" x="89.5" y="42" width="275" height="55"/>
+                                                    <rect key="frame" x="83" y="42" width="282.5" height="55"/>
                                                     <subviews>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="HeritageTitle" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="r7h-De-GgE">
                                                             <rect key="frame" x="0.0" y="0.0" width="135.5" height="30"/>
@@ -53,7 +53,7 @@
                                                 </stackView>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstItem="bjC-mT-xWS" firstAttribute="width" secondItem="KiE-qJ-dhk" secondAttribute="width" multiplier="0.2" constant="6.5999999999999943" id="9gf-mJ-eW9"/>
+                                                <constraint firstItem="bjC-mT-xWS" firstAttribute="width" secondItem="KiE-qJ-dhk" secondAttribute="width" multiplier="0.2" id="9gf-mJ-eW9"/>
                                             </constraints>
                                         </stackView>
                                     </subviews>
@@ -90,37 +90,28 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NWm-mX-9Gl">
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="NWm-mX-9Gl">
                                 <rect key="frame" x="0.0" y="44" width="414" height="818"/>
                                 <subviews>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="z7b-3U-6Za" userLabel="Content View">
+                                    <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="z7b-3U-6Za" userLabel="Content View">
                                         <rect key="frame" x="0.0" y="0.0" width="414" height="1659"/>
                                         <subviews>
-                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="23" translatesAutoresizingMaskIntoConstraints="NO" id="Tiu-RV-0NI">
-                                                <rect key="frame" x="15" y="0.0" width="384" height="1659"/>
-                                                <subviews>
-                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="haegeum" adjustsImageSizeForAccessibilityContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="c6V-hi-m1H">
-                                                        <rect key="frame" x="0.0" y="0.0" width="384" height="1430"/>
-                                                    </imageView>
-                                                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" textAlignment="natural" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ibv-R5-9y5">
-                                                        <rect key="frame" x="0.0" y="1453" width="384" height="206"/>
-                                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                                        <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
-                                                        <color key="textColor" systemColor="labelColor"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                        <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
-                                                        <dataDetectorType key="dataDetectorTypes" address="YES"/>
-                                                    </textView>
-                                                </subviews>
-                                            </stackView>
+                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="haegeum" adjustsImageSizeForAccessibilityContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="c6V-hi-m1H">
+                                                <rect key="frame" x="15" y="114" width="384" height="1430"/>
+                                                <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
+                                            </imageView>
+                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" scrollEnabled="NO" editable="NO" textAlignment="natural" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ibv-R5-9y5">
+                                                <rect key="frame" x="15" y="726" width="384" height="206"/>
+                                                <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
+                                                <color key="textColor" systemColor="labelColor"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                                <dataDetectorType key="dataDetectorTypes" address="YES"/>
+                                            </textView>
                                         </subviews>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                        <constraints>
-                                            <constraint firstAttribute="bottom" secondItem="Tiu-RV-0NI" secondAttribute="bottom" id="Pys-qd-j8o"/>
-                                            <constraint firstItem="Tiu-RV-0NI" firstAttribute="leading" secondItem="z7b-3U-6Za" secondAttribute="leading" constant="15" id="YjJ-2X-8WO"/>
-                                            <constraint firstItem="Tiu-RV-0NI" firstAttribute="top" secondItem="z7b-3U-6Za" secondAttribute="top" id="bpO-XW-Svv"/>
-                                            <constraint firstAttribute="trailing" secondItem="Tiu-RV-0NI" secondAttribute="trailing" constant="15" id="pF7-2d-wjm"/>
-                                        </constraints>
                                     </view>
                                 </subviews>
                                 <constraints>
@@ -146,6 +137,8 @@
                     <connections>
                         <outlet property="heritageDescriptionTextView" destination="Ibv-R5-9y5" id="aK8-Mv-1dW"/>
                         <outlet property="heritageImageView" destination="c6V-hi-m1H" id="8Qe-ma-uU8"/>
+                        <outlet property="heritageScrollContentView" destination="z7b-3U-6Za" id="9be-04-YDb"/>
+                        <outlet property="heritageScrollView" destination="NWm-mX-9Gl" id="rUy-rc-D1j"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="nz2-W1-KhJ" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -320,10 +313,10 @@
             </objects>
             <point key="canvasLocation" x="75" y="17"/>
         </scene>
-        <!--Navigation Controller-->
+        <!--Main Navigation Controller-->
         <scene sceneID="0vA-gE-A8V">
             <objects>
-                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="LHX-wM-DhN" sceneMemberID="viewController">
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="LHX-wM-DhN" customClass="MainNavigationController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="u01-2M-jcZ">
                         <rect key="frame" x="0.0" y="44" width="414" height="44"/>

--- a/Expo1900/Expo1900/ViewController/ExpoViewController.swift
+++ b/Expo1900/Expo1900/ViewController/ExpoViewController.swift
@@ -28,6 +28,10 @@ class ExpoViewController: UIViewController {
         }
     }()
     
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        return .portrait
+    }
+        
     override func viewDidLoad() {
         super.viewDidLoad()
         configureLabelText()
@@ -35,6 +39,7 @@ class ExpoViewController: UIViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        UIDevice.current.setValue(UIInterfaceOrientation.portrait.rawValue, forKey: "orientation")
         navigationController?.setNavigationBarHidden(true, animated: animated)
     }
     

--- a/Expo1900/Expo1900/ViewController/HeritageViewController.swift
+++ b/Expo1900/Expo1900/ViewController/HeritageViewController.swift
@@ -11,14 +11,46 @@ class HeritageViewController: UIViewController {
 
     @IBOutlet weak var heritageImageView: UIImageView!
     @IBOutlet weak var heritageDescriptionTextView: UITextView!
+    @IBOutlet weak var heritageScrollView: UIScrollView!
+    @IBOutlet weak var heritageScrollContentView: UIView!
     
     var heritage: Heritage?
+    lazy var portraitConstraints: [NSLayoutConstraint] = {
+        return [heritageImageView.topAnchor.constraint(equalTo: heritageScrollContentView.topAnchor),
+                heritageImageView.centerXAnchor.constraint(equalTo: heritageScrollContentView.centerXAnchor),
+                heritageImageView.widthAnchor.constraint(lessThanOrEqualTo: heritageScrollContentView.widthAnchor, multiplier: 1),
+                heritageDescriptionTextView.topAnchor.constraint(equalTo: heritageImageView.bottomAnchor, constant: 20),
+                heritageDescriptionTextView.leadingAnchor.constraint(equalTo: heritageScrollContentView.leadingAnchor),
+                heritageDescriptionTextView.trailingAnchor.constraint(equalTo: heritageScrollContentView.trailingAnchor),
+                heritageDescriptionTextView.bottomAnchor.constraint(equalTo: heritageScrollContentView.bottomAnchor)
+        ]
+    }()
+    
+    lazy var landscapeConstraints: [NSLayoutConstraint] = {
+        let frameLayout = heritageScrollView.frameLayoutGuide
+        
+        return [heritageImageView.heightAnchor.constraint(lessThanOrEqualTo: frameLayout.heightAnchor, multiplier: 1),
+                heritageImageView.widthAnchor.constraint(lessThanOrEqualTo: frameLayout.widthAnchor, multiplier: 0.3),
+                heritageImageView.leadingAnchor.constraint(equalTo: frameLayout.leadingAnchor),
+                heritageImageView.centerYAnchor.constraint(equalTo: frameLayout.centerYAnchor),
+                heritageDescriptionTextView.leadingAnchor.constraint(equalTo: heritageImageView.trailingAnchor, constant: 20),
+                heritageDescriptionTextView.trailingAnchor.constraint(equalTo: heritageScrollContentView.trailingAnchor),
+                heritageDescriptionTextView.topAnchor.constraint(equalTo: heritageScrollContentView.topAnchor),
+                heritageDescriptionTextView.bottomAnchor.constraint(equalTo: heritageScrollContentView.bottomAnchor)
+        ]
+    }()
     
     override func viewDidLoad() {
         super.viewDidLoad()
         navigationItem.title = heritage?.name
+        disableAutoresizingMasks()
         configureHeritageViews()
         configureHeritageImageViewRatioConstraint()
+        switchConstraintsByOrientation()
+    }
+    
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        switchConstraintsByOrientation()
     }
     
     private func configureHeritageViews() {
@@ -31,5 +63,20 @@ class HeritageViewController: UIViewController {
         guard let heritage = heritage ,let image = UIImage(named: heritage.imageName) else { return }
         let imageRatio = image.size.width / image.size.height
         heritageImageView.widthAnchor.constraint(equalTo: heritageImageView.heightAnchor, multiplier: imageRatio).isActive = true
+    }
+    
+    private func disableAutoresizingMasks() {
+        heritageImageView.translatesAutoresizingMaskIntoConstraints = false
+        heritageDescriptionTextView.translatesAutoresizingMaskIntoConstraints = false
+    }
+    
+    private func switchConstraintsByOrientation() {
+        if UIDevice.current.orientation.isLandscape {
+            NSLayoutConstraint.deactivate(portraitConstraints)
+            NSLayoutConstraint.activate(landscapeConstraints)
+        } else {
+            NSLayoutConstraint.deactivate(landscapeConstraints)
+            NSLayoutConstraint.activate(portraitConstraints)
+        }
     }
 }

--- a/Expo1900/Expo1900/ViewController/MainNavigationController.swift
+++ b/Expo1900/Expo1900/ViewController/MainNavigationController.swift
@@ -1,0 +1,16 @@
+//
+//  MainNavigationController.swift
+//  Expo1900
+//
+//  Created by kakao on 2022/01/17.
+//
+
+import UIKit
+
+class MainNavigationController: UINavigationController {
+
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        return visibleViewController?.supportedInterfaceOrientations ?? .all
+    }
+    
+}


### PR DESCRIPTION
## 구현 내용
### 메인 화면 세로 화면 강제
- MainNavigationController로 커스텀 클래스를 만든 후 supportedInterfaceOrientations를 오버라이드하여
현재 가장 상단에 있는 visibleViewController의 값을 반환하게 하여 viewController에서 화면 모드를 선택할 수 있도록 했습니다
- 가로 모드로 메인화면에 뒤로가기 해서 넘어오는 경우 위의 설정이 먹히지 않아 ExpoViewController의 viewWillAppear에
UIDevice의 orientation을 강제로 portrait로 설정해주는 코드를 추가했습니다
### 출품작 상세 가로 화면 구현
- 기존 Stack View를 없애고 이미지와 레이블에 가로일 때와 세로일 때 두가지 contraint set을 정의하고
이것이 viewWillTransition에서 UIDevice의 orientation에 따라 active/inactive 상태가 전환될 수 있도록 하였습니다
## 고민했던 점
1.  IBoutlet Constraints vs Constraints In Code
이번 Bonus Step, 출품작 상세 화면에서 가로 회전 시에 세로와 다른 UI를 표시하기 위해서 런타임에 Constraint를 수정하여 해결하였습니다. 
현재는 코드 내에서 세로일때와 가로일떄의 제약조건들을 배열로 저장하고 이를 orientation에 맞추어 activate, deactivate 하는 방식으로 진행하였습니다.  
이 Constraint들에 관해서 질문이 있습니다. 
```@IBOutlet var portraitConstraints: [NSLayoutConstraint]```를 선언해주고 스토리보드에 각각 제약조건을 건 다음 연결시켜주는 방식도 고민했습니다.
이 방법 또한 올바른 방법이라고 생각되는데 다만 배열로 할 경우 weak 키워드를 사용할 수 없다는 점이 걸렸습니다. (배열은 value type이기 때문에) IBOutlet 배열로 저장하는 방식은 틀린 방법인지 혹은 한번 wrapping하여 사용해야하는지 궁금합니다.
2. TabieViewCell안의 ImageView aspect ratio constraint
HeritageTableViewController 화면에서 가로 회전시에 오토레이아웃 충돌이 발생한다는 사실을 알았습니다.
이때 어떤 레이아웃이 충돌되는지 명확하게 드러나지 않아, 많은 시도를 해보다가 TableViewCell안의 ImageView의 aspect ratio 제약조건의 priority를 낮추었더니 해결되었습니다.
충돌이 일어날 때를 WTF를 이용해서 분석해보기도했는데 너무 많은 것들이 후보로 나와서 어디서 충돌이 나는 것인지 분석할 수 없었으나,
이미지 뷰가 문제가 될 것이라 생각하여 ratio constraint를 없애봤더니 에러가 사라졌습니다.
그 후  priority를 낮추는 방법을 이용했더니 해결되었습니다. 그에 대한 이유를 둘이 열심히 고민해봤는데 도저히 이해가 안돼서 질문드립니다.
에러는 TableViewCell의 ImageView의 ratio constraint의 priority를 1000으로 올리고 화면을 회전을 하면 재현이 됩니다!

cc. @zdodev 